### PR TITLE
Add a default branch in case statement

### DIFF
--- a/src/main/java/drake/Storage.java
+++ b/src/main/java/drake/Storage.java
@@ -39,7 +39,7 @@ public class Storage {
      *
      * @return A list of Tasks present in the task file.
      */
-    public List<Task> fileToList() {
+    public List<Task> fileToList() throws UnknownCommandException {
         ArrayList<Task> list = new ArrayList<>();
         Scanner fileReader;
         try {
@@ -71,6 +71,8 @@ public class Storage {
                 }
                 list.add(event);
                 break;
+            default:
+                throw new UnknownCommandException();
             }
         }
         return list;


### PR DESCRIPTION
The fileToList() method assumes that the task file data is always correct.

The task file data may get corrupted.

Let's use a default branch to throw an exception in case inappropriate data is encountered.

Using an exception allows us to document unexpected behaviour.